### PR TITLE
Update button UI to look closer to existing comps

### DIFF
--- a/src/components/assets/Icons.js
+++ b/src/components/assets/Icons.js
@@ -1,20 +1,75 @@
 // @flow
-/* eslint-disable import/prefer-default-export */
 import React from 'react'
-import Svg, { Line } from 'react-native-svg'
-import type { JSO } from '../../types/flowtypes'
+import Svg, { G, Path, Polygon, Polyline } from 'react-native-svg'
 
 type Props = {
-  style?: JSO | null,
+  children : React.Element<*>,
 }
 
-export const DismissIcon = (props: Props) =>
-  <Svg style={{ ...props.style }} height="20" width="20">
-    <Line stroke="#aaa" strokeWidth="1.25" x1="6" x2="14" y1="6" y2="14" />
-    <Line stroke="#aaa" strokeWidth="1.25" x1="14" x2="6" y1="6" y2="14" />
+// Yo! Strokes and fills are element attributes and not styles
+const baseStroke = {
+  stroke: '#aaa',
+  strokeWidth: 1.25,
+  fill: 'none',
+}
+
+const greenStroke = {
+  stroke: '#00d100',
+  strokeWidth: 1.25,
+  fill: 'none',
+}
+
+const blackFill = {
+  fill: '#000',
+  stroke: 'none',
+}
+
+const SvgIcon = ({ children, ...props }: Props) =>
+  <Svg height={20} width={20} {...props} >
+    {children}
   </Svg>
 
-DismissIcon.defaultProps = {
-  style: {},
-}
+// -------------------------------------
+
+export const CameraIcon = ({ ...rest }: any) =>
+  <SvgIcon {...rest} width={24}>
+    <G x={0} y={2}>
+      <Polygon {...baseStroke} points="0.625 16.625 21.425 16.625 21.425 0.625 0.625 0.625" />
+      <Path {...baseStroke} d="M15.025,8.625 C15.025,10.834 13.234,12.625 11.025,12.625 C8.816,12.625 7.025,10.834 7.025,8.625 C7.025,6.416 8.816,4.625 11.025,4.625 C13.234,4.625 15.025,6.416 15.025,8.625 Z" />
+    </G>
+  </SvgIcon>
+
+export const DismissIcon = ({ ...rest }: any) =>
+  <SvgIcon {...rest} >
+    <G x={3} y={3}>
+      <Path {...baseStroke} d="M0.4419,0.442 L12.4419,12.442" />
+      <Path {...baseStroke} d="M12.4419,0.442 L0.4419,12.442" />
+    </G>
+  </SvgIcon>
+
+// TODO: Need to rethink modifiers here... this won't scale super well.
+export const MiniCheckMark = ({ modifier, ...rest }: any) =>
+  <SvgIcon {...rest}>
+    <G x={0} y={0}>
+      <Polyline
+        {...(modifier === 'inPostActions' ? greenStroke : baseStroke)}
+        points="12 5.61573 14.458 8.70673 18 2.70673"
+      />
+    </G>
+  </SvgIcon>
+
+export const MoneyIcon = ({ ...rest }: any) =>
+  <SvgIcon {...rest}>
+    <G x={0} y={1} width={25}>
+      <Path {...blackFill} d="M5.6196,13.8295 C7.4076,13.6285 8.0826,12.6985 8.0826,11.4395 C8.0826,10.2715 7.3896,9.4505 5.7286,9.1405 L5.5106,9.1045 L5.5106,13.8295 L5.6196,13.8295 Z M4.3056,2.7725 C2.8456,2.9735 2.0436,3.9225 2.0436,5.0355 C2.0436,6.4225 2.9006,7.0795 4.1786,7.2975 L4.3056,7.3155 L4.3056,2.7725 Z M4.3056,17.2235 L4.3056,15.2345 C1.5146,15.0515 0.2006,13.4455 -0.000400000001,11.2385 L1.6236,11.2385 C1.8246,12.4975 2.5366,13.6465 4.3056,13.8475 L4.3056,8.8665 L3.9776,8.8125 C1.7326,8.3925 0.4746,7.2435 0.4746,5.0355 C0.4746,3.1375 2.0436,1.6785 4.3056,1.4595 L4.3056,-0.0005 L5.5106,-0.0005 L5.5106,1.4595 C7.9736,1.6785 9.3596,3.1375 9.4696,5.2545 L7.8636,5.2545 C7.7176,4.0685 7.0796,3.0105 5.5106,2.7725 L5.5106,7.5355 L6.0396,7.6265 C8.7396,8.1005 9.7246,9.3775 9.7246,11.2935 C9.7246,13.5925 8.2656,15.0335 5.5106,15.2345 L5.5106,17.2235 L4.3056,17.2235 Z" />
+    </G>
+  </SvgIcon>
+
+export const PencilIcon = ({ disabled, ...rest }: any) =>
+  <SvgIcon {...rest}>
+    <G x={4} y={17} rotate={-90}>
+      <Path stroke="none" fill={disabled ? '#aaa' : '#fff'} d="M1.5683,1.8963 L3.8083,1.8963 L10.9833,8.9883 L8.7493,11.1963 L1.5683,4.0973 L1.5683,1.8963 Z M4.2693,0.7743 L0.4463,0.7743 L0.4463,4.5663 L8.7493,12.7743 L12.5793,8.9883 L4.2693,0.7743 Z" />
+      <Polygon stroke="none" fill={disabled ? '#aaa' : '#fff'} points="9.6312 6.0648 5.8012 9.8508 6.5902 10.6488 10.4202 6.8628" />
+    </G>
+  </SvgIcon>
 

--- a/src/components/buttons/Buttons.js
+++ b/src/components/buttons/Buttons.js
@@ -1,0 +1,77 @@
+// @flow
+/* eslint-disable import/prefer-default-export */
+import React from 'react'
+// $FlowFixMe
+import { Text, TouchableOpacity, View } from 'react-native'
+import { PencilIcon } from '../assets/Icons'
+
+type Props = {
+  children: React.Element<*>,
+  disabled?: boolean,
+}
+
+const disabledOpacityStyle = {
+  opacity: 0.2,
+}
+
+// -------------------------------------
+
+const iconButtonStyle = {
+  justifyContent: 'center',
+  alignItems: 'center',
+  minWidth: 44,
+  minHeight: 44,
+  marginRight: 5,
+}
+
+export const IconButton = ({ children, disabled, ...props }: Props) =>
+  <TouchableOpacity style={iconButtonStyle} disabled={disabled} {...props} >
+    <View style={disabled && disabledOpacityStyle}>
+      {children}
+    </View>
+  </TouchableOpacity>
+
+IconButton.defaultProps = {
+  disabled: false,
+}
+
+// -------------------------------------
+
+const postButtonStyle = {
+  flex: 1,
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  minWidth: 44,
+  minHeight: 44,
+  paddingHorizontal: 40,
+  backgroundColor: 'black',
+}
+
+const postButtonTextStyleBase = {
+  marginLeft: 5,
+  fontSize: 14,
+}
+
+const postButtonTextStyle = {
+  ...postButtonTextStyleBase,
+  color: '#fff',
+}
+
+const postButtonTextStyleDisabled = {
+  ...postButtonTextStyleBase,
+  color: '#aaa',
+}
+
+export const PostButton = ({ children, disabled, ...props }: Props) =>
+  <TouchableOpacity style={postButtonStyle} disabled={disabled} {...props} >
+    <PencilIcon disabled={disabled} />
+    <Text style={disabled ? postButtonTextStyleDisabled : postButtonTextStyle}>
+      {children}
+    </Text>
+  </TouchableOpacity>
+
+PostButton.defaultProps = {
+  disabled: false,
+}
+

--- a/src/components/editor/Block.js
+++ b/src/components/editor/Block.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { View } from 'react-native'
+import { IconButton } from '../buttons/Buttons'
+import { DismissIcon } from '../assets/Icons'
 
 const viewStyle = {
   padding: 10,
@@ -15,18 +17,9 @@ const subViewStyle = {
 }
 
 const closeBtnStyle = {
-  alignItems: 'center',
-  height: 30,
-  justifyContent: 'center',
   position: 'absolute',
-  right: 0,
-  top: 0,
-  width: 30,
-}
-
-const closeTextStyle = {
-  color: '#aaa',
-  fontSize: 22,
+  right: -10,
+  top: -5,
 }
 
 const Block = ({ children, hasContent, uid }, { onClickRemoveBlock }) =>
@@ -34,12 +27,11 @@ const Block = ({ children, hasContent, uid }, { onClickRemoveBlock }) =>
     <View style={subViewStyle}>
       {children}
       {hasContent &&
-        <TouchableOpacity
-          onPress={() => onClickRemoveBlock(uid)}
-          style={closeBtnStyle}
-        >
-          <Text style={closeTextStyle}>&times;</Text>
-        </TouchableOpacity>
+        <View style={closeBtnStyle}>
+          <IconButton onPress={() => onClickRemoveBlock(uid)}>
+            <DismissIcon />
+          </IconButton>
+        </View>
       }
     </View>
   </View>

--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -10,7 +10,6 @@ import {
   Modal,
   ScrollView,
   Text,
-  TouchableOpacity,
   View,
 } from 'react-native'
 import { connect } from 'react-redux'
@@ -58,7 +57,8 @@ import {
   selectIsOwnPage,
   selectProfileIsFeatured,
 } from '../../selectors/profile'
-import { DismissIcon } from '../assets/Icons'
+import { CameraIcon, DismissIcon, MiniCheckMark, MoneyIcon } from '../assets/Icons'
+import { IconButton, PostButton } from '../buttons/Buttons'
 import EmbedBlock from './EmbedBlock'
 import ImageBlock from './ImageBlock'
 import RepostBlock from './RepostBlock'
@@ -164,23 +164,19 @@ function mapStateToProps(state, props) {
 const toolbarStyle = {
   flexDirection: 'row',
   height: 60,
+}
+const toolbarLeftStyle = {
+  flex: 1,
+  flexDirection: 'row',
+  justifyContent: 'flex-start',
+}
+const toolbarRightStyle = {
+  flex: 1,
+  flexDirection: 'row',
   justifyContent: 'flex-end',
-  padding: 10,
 }
-const buttonStyle = {
-  marginLeft: 10,
-}
-const dismissButtonStyle = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-}
-const buttonTextStyle = {
-  backgroundColor: '#000',
-  borderRadius: 20,
-  color: '#fff',
-  paddingHorizontal: 20,
-  paddingVertical: 10,
+const footerStyle = {
+  height: 44,
 }
 const activityIndicatorViewStyle = {
   alignItems: 'center',
@@ -196,6 +192,11 @@ const postingTextStyle = {
   marginBottom: 20,
   paddingHorizontal: 20,
   paddingVertical: 10,
+}
+const moneyCheckMarkWrapperStyle = {
+  position: 'absolute',
+  top: -2,
+  right: 0,
 }
 
 class Editor extends Component {
@@ -270,7 +271,7 @@ class Editor extends Component {
 
   state = {
     completerType: null,
-    scrollViewHeight: null,
+    scrollViewHeight: Dimensions.get('window').height - (toolbarStyle.height + footerStyle.height),
   }
 
   getChildContext() {
@@ -639,11 +640,11 @@ class Editor extends Component {
 
   keyboardDidHide = () => {
     this.onHideCompleter()
-    this.setState({ scrollViewHeight: (Dimensions.get('window').height - toolbarStyle.height) })
+    this.setState({ scrollViewHeight: (Dimensions.get('window').height - (toolbarStyle.height + footerStyle.height)) })
   }
 
   keyboardDidShow = ({ endCoordinates: { screenY } }) => {
-    this.setState({ scrollViewHeight: (screenY - toolbarStyle.height) })
+    this.setState({ scrollViewHeight: (screenY - (toolbarStyle.height + footerStyle.height)) })
   }
 
   handleHardwareBackPress = () => {
@@ -701,38 +702,31 @@ class Editor extends Component {
       repostContent,
       submitText,
     } = this.props
-    let buyLinkBgColor = !hasMedia ? '#aaa' : '#000'
-    if (buyLink && buyLink.length) { buyLinkBgColor = '#00d100' }
     const isPostingDisabled = isPosting || isLoading || !hasContent
     const key = `${editorId}_${(blocks ? blocks.size : '') + (repostContent ? repostContent.size : '')}`
     return (
       <View key={key} style={{ flex: 1, backgroundColor: hasMention ? '#ffc' : '#eee' }}>
         <View style={toolbarStyle}>
-          {hasContent &&
-            <TouchableOpacity
-              onPress={this.onResetEditor}
-              style={dismissButtonStyle}
-            >
-              <DismissIcon />
-            </TouchableOpacity>
-          }
-          <TouchableOpacity
-            disabled={!hasMedia}
-            onPress={this.onLaunchBuyLinkModal}
-            style={buttonStyle}
-          >
-            <Text style={{ ...buttonTextStyle, backgroundColor: buyLinkBgColor }}>$</Text>
-          </TouchableOpacity>
-          <TouchableOpacity onPress={this.onShowImageOptions} style={buttonStyle}>
-            <Text style={buttonTextStyle}>&#x1f4f7;</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            disabled={isPostingDisabled}
-            onPress={this.onSubmitPost}
-            style={buttonStyle}
-          >
-            <Text style={{ ...buttonTextStyle, backgroundColor: isPostingDisabled ? '#aaa' : '#00d100' }}>{submitText}</Text>
-          </TouchableOpacity>
+          <View style={toolbarLeftStyle}>
+            {hasContent &&
+              <IconButton onPress={this.onResetEditor}>
+                <DismissIcon />
+              </IconButton>
+            }
+          </View>
+          <View style={toolbarRightStyle}>
+            <IconButton disabled={!hasMedia} onPress={this.onLaunchBuyLinkModal}>
+              {buyLink && buyLink.length &&
+                <View style={moneyCheckMarkWrapperStyle}>
+                  <MiniCheckMark modifier="inPostActions" />
+                </View>
+              }
+              <MoneyIcon />
+            </IconButton>
+            <IconButton onPress={this.onShowImageOptions}>
+              <CameraIcon />
+            </IconButton>
+          </View>
         </View>
         <View style={{ height: this.state.scrollViewHeight }}>
           <ScrollView
@@ -747,6 +741,11 @@ class Editor extends Component {
             onCancel={this.onCancelAutoCompleter}
             onCompletion={this.onCompletion}
           />
+        </View>
+        <View style={footerStyle}>
+          <PostButton disabled={isPostingDisabled} onPress={this.onSubmitPost}>
+            {submitText}
+          </PostButton>
         </View>
         <Modal
           animationType="fade"


### PR DESCRIPTION
Probably not exactly what we want, but at least it starts to put the pieces in place. With the post button on the bottom we still get some funky layout issues once there are multiple blocks. I believe this is what we've been seeing with the Completers as well. Also updated the icon for dismissing a block.

[Finishes: #143557767](https://www.pivotaltracker.com/story/show/143557767)

It looks like 👇 

<img width="399" alt="screen shot 2017-04-12 at 1 17 14 am" src="https://cloud.githubusercontent.com/assets/78967/24945761/d4b0e95c-1f1d-11e7-8dba-cbd7bffe6b08.png">
