### PR TITLE
Display web app domain alert dialog for staff users

### DIFF
--- a/android/app/src/main/java/co/ello/ElloApp/ElloPreferences.java
+++ b/android/app/src/main/java/co/ello/ElloApp/ElloPreferences.java
@@ -9,6 +9,8 @@ public class ElloPreferences {
     public static final String SENT_TOKEN_TO_SERVER = "sentTokenToServer";
     public static final String REGISTRATION_COMPLETE = "registrationComplete";
     public static final String PUSH_RECEIVED = "pushReceived";
+    public static final String IS_STAFF = "isStaff";
+    public static final String WEBAPP_DOMAIN = "webappDomain";
     // oddly this is hard coded into react-native-shared-preferences so we need it here
     public static final String PREFERENCES_KEY = "wit_player_shared_preferences";
 }


### PR DESCRIPTION
We now allow staff users to switch between webapp domains similar to the iOS experience. Shaking the phone while logged in as a staff member will present you with:

stage 1, stage 2, ninja, prod

Switching to a new environment will reload the web view and load the root page for the environment. Conveniently, reloading the web view with the given domain will take care of all environment variables including `client id` and `client secret` due to the baked in behavior of web app and the architecture of how the wrapper and react native get their data.  

[Finishes #143833781](https://www.pivotaltracker.com/story/show/143833781)