### PR TITLE
Force Gradle subprojects to use the same buildTools/sdk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,8 +86,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "co.ello.ElloApp"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,29 +1,46 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:2.3.1'
 
-        classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+      classpath 'com.google.gms:google-services:3.0.0'
+      classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+      // NOTE: Do not place your application dependencies here; they belong
+      // in the individual module build.gradle files
+  }
 }
 
 allprojects {
-    repositories {
-        mavenLocal()
-        jcenter()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
-        }
+  repositories {
+    mavenLocal()
+      jcenter()
+      maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+      }
+  }
+}
+
+// Force subprojects to use the same sdk/build-tools versions
+// http://stackoverflow.com/questions/24494077/gradle-force-build-tools-version-on-third-party-libraries
+ext {
+  compileSdkVersion = 23
+    buildToolsVersion = "25.0.0"
+}
+subprojects { subproject ->
+  afterEvaluate{
+    if((subproject.plugins.hasPlugin('android') || subproject.plugins.hasPlugin('android-library'))) {
+      android {
+        compileSdkVersion rootProject.ext.compileSdkVersion
+          buildToolsVersion rootProject.ext.buildToolsVersion
+      }
     }
+  }
 }
 
 // Limit resource usage on Travis
@@ -35,7 +52,7 @@ if (System.env.TRAVIS == 'true') {
     tasks.withType(Test) {
       // containers (currently) have 2 dedicated cores and 4GB of memory
       maxParallelForks = 2
-      minHeapSize = '128m'
+        minHeapSize = '128m'
     }
   }
 }


### PR DESCRIPTION
This should eliminate the editing-nodemodules-after-clean dance we've been doing.

/cc @steam 