### PR TITLE
Allow the app to be installed on external storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="co.ello.ElloApp"
     android:versionCode="1"
-    android:versionName="1.0">
+    android:versionName="1.0"
+    android:installLocation="auto" >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>


### PR DESCRIPTION
[Looking at the docs](https://developer.android.com/guide/topics/data/install-location.html), I don't think there are any major drawbacks to this though I could be wrong. Seems like the push listener might get killed if external media is unmounted, though it may get restarted if it's remounted?