### PR TITLE
Add rate prompt

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,6 +155,7 @@ dependencies {
     compile project(':react-native-config')
     compile project(':react-native-image-picker')
     compile project(':react-native-svg')
+    compile 'com.github.hotchemi:android-rate:1.0.1'
     compile 'com.orhanobut:hawk:2.0.1'
     compile 'com.squareup:seismic:1.0.2'
     compile "com.android.support:appcompat-v7:25.0.0"

--- a/android/app/src/main/java/co/ello/ElloApp/MainActivity.java
+++ b/android/app/src/main/java/co/ello/ElloApp/MainActivity.java
@@ -44,6 +44,8 @@ import org.xwalk.core.XWalkView;
 import java.util.Date;
 
 import co.ello.ElloApp.PushNotifications.RegistrationIntentService;
+import hotchemi.android.rate.AppRate;
+import hotchemi.android.rate.OnClickButtonListener;
 
 // Using a 3rd party Snackbar because we can't extend
 // AppCompatActivity, thanks a lot XWalkActivity
@@ -102,6 +104,7 @@ public class MainActivity
         setupWebView();
         setupRegisterDeviceReceiver();
         setupPushReceivedReceiver();
+        setupRatePrompt();
     }
 
     protected void onXWalkReady() {
@@ -341,6 +344,14 @@ public class MainActivity
         }
     }
 
+    private void track(String name) {
+        if(name != null) {
+            String trackFunctionCall =
+                    "javascript:trackAndroidEvent(\"" + name + "\")";
+            xWalkView.load(trackFunctionCall, null);
+        }
+    }
+
     private void setupRegisterDeviceReceiver() {
         registerDeviceReceiver = new BroadcastReceiver() {
             @Override
@@ -391,7 +402,35 @@ public class MainActivity
         registerReceiver(pushReceivedReceiver, new IntentFilter(ElloPreferences.PUSH_RECEIVED));
     }
 
+    private void setupRatePrompt(){
+        AppRate.with(this)
+            .setInstallDays(7)
+            .setLaunchTimes(3)
+            .setRemindInterval(7)
+            .setShowLaterButton(true)
+            .setDebug(true)
+            .setOnClickButtonListener(new OnClickButtonListener() {
+                @Override
+                public void onClickButton(int which) {
+                    switch (which) {
+                        case -1: track("rate prompt user attempted to rate app");
+                            break;
+                        case -2: track("rate prompt user declined to rate app");
+                            break;
+                        case -3: track("rate prompt remind me later");
+                            break;
+                        default:
+                                break;
+                    }
+                }
+            })
+            .monitor();
 
+        Boolean showRateDialog = AppRate.showRateDialogIfMeetsConditions(this);
+        if(showRateDialog) {
+            track("rate prompt shown");
+        }
+    }
 
     private void deepLinkWhenPresent(){
         if (progress == null) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,4 +14,9 @@
     <string name="couldnt_connect_error">No Internet Connection</string>
     <string name="title_activity_no_internets">NoInternetsActivity</string>
     <string name="view">View</string>
+    <string name="rate_dialog_title">Love Ello?</string>
+    <string name="rate_dialog_message"></string>
+    <string name="rate_dialog_ok">Rate us: ⭐️⭐️⭐️⭐️⭐️</string>
+    <string name="rate_dialog_cancel">Remind Me Later</string>
+    <string name="rate_dialog_no">No Thanks</string>
 </resources>


### PR DESCRIPTION
Adds https://github.com/hotchemi/Android-Rate

I’ve matched everything possible with iOS. 7 days after install, at least 3 launches of the app, 7 day reminder. The only thing this doesn’t have is a “X number of events” trigger. On iOS we launch it after 3 views of the following screen. We lose that ability on Android with this library.

Tracking:
track("rate prompt shown");
track("rate prompt user attempted to rate app");
track("rate prompt user declined to rate app");
track("rate prompt remind me later");

Present on iOS but not part of Android:
track("rate prompt opened app store")
track("rate prompt could not connect to app store")

[Finishes #145288613](https://www.pivotaltracker.com/story/show/145288613)